### PR TITLE
fix wait_for task when using non-default network interface

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,13 +14,11 @@ galaxy_info:
   # (usually master) will be used.
   github_branch: master
 
-  #
-  # platforms is a list of platforms, and each platform has a name and a list of versions.
-  #
   platforms:
     - name: Ubuntu
       versions:
         - 16.04
+        - 18.04
 
   galaxy_tags:
     - apache
@@ -28,6 +26,5 @@ galaxy_info:
     - cluster
     - database
 
+# java is a dependency, but to allow flexibility, no particular ansible role is set here. See README.md for details and a java role dependency suggestion.
 dependencies: []
-# List your role dependencies here, one per line. Be sure to remove the '[]' above,
-# if you add dependencies to this list.

--- a/tasks/systemd.yml
+++ b/tasks/systemd.yml
@@ -26,7 +26,7 @@
 
 - name: Wait for cassandra to startup
   wait_for:
-    host: "{{ ansible_default_ipv4.address }}"
+    host: "{{ hostvars[inventory_hostname]['ansible_' + cassandra_network_interface].ipv4.address }}"
     port: "{{ item }}"
     delay: 5
     connect_timeout: 1


### PR DESCRIPTION
Fixes timing out when setting `cassandra_network_interface` to a different-than-default one. 