### PR TITLE
Repair all keyspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ansible role to install an Apache Cassandra cluster supervised by systemd. Inclu
 * Some OS tuning options such as installing jemalloc, setting max_map_count and tcp_keepalive, disabling swap.
 * Bootstraps nodes using the IPs of the servers in the `cassandra_seed` (configurable) inventory group.
 * Weekly scheduled repairs via cron jobs that are non-overlapping (see `cassandra_repair_slots`).
-    * requires setting `cassandra_keyspaces` (default `[]` will have no effect)
+    * Note that **all** keyspaces will be scheduled for repairs
 * Incremental and full backup scripts as well as a restore script. (disabled by default, optional) (NOTE: needs better testing)
     * backup/restore requires access to S3.
 * prometheus-style metrics using jmx-exporter
@@ -40,12 +40,6 @@ Give your cluster a better name:
 ```yaml
 # set cassandra_cluster_name before running the playbook for the first time; never change it afterwards
 cassandra_cluster_name: default
-```
-
-You should override the keyspaces to match keyspaces on which you wish to run weekly repairs:
-
-```yaml
-cassandra_keyspaces: []
 ```
 
 You may wish to override the following defaults to enable backups:
@@ -108,8 +102,6 @@ Then the following should work and start your cluster:
   vars:
     # set cluster_name before running the playbook for the first time; never change it afterwards
     cassandra_cluster_name: my_cluster
-    cassandra_keyspaces:
-      - my_keyspace1
     # set installed java package version manually. required when using Ubuntu 18.04. see: [A note on Java 8 and Ubuntu 18.04](#a-note-on-Java-8-and-Ubuntu-18.04)
     java_packages: openjdk-8-jdk
   roles:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,7 +45,6 @@ cassandra_env: dev
 cassandra_cluster_name: default
 cassandra_role: 'cassandra_{{ cassandra_cluster_name }}'
 cassandra_seed_role: '{{ cassandra_role }}_seed'
-cassandra_keyspaces: []
 cassandra_metrics_prefix: 'cassandra_{{ cassandra_cluster_name }}'
 
 cassandra_snitch: '{% if is_aws_environment %}Ec2Snitch{% else %}SimpleSnitch{% endif %}'

--- a/templates/cassandra_repair.j2
+++ b/templates/cassandra_repair.j2
@@ -11,11 +11,11 @@ metrics_file=${metrics_dir}/cassandra_repair.prom
 metrics_tmpl='
 # TYPE cassandra_repair counter
 # HELP cassandra_repair Counts the number of repairs and the status
-cassandra_repair{status="%s",errno="%d",keyspace="%s"} 1 %d
+cassandra_repair{status="%s",errno="%d"} 1 %d
 
 # TYPE cassandra_repair_duration_seconds gauge
 # HELP cassandra_repair_duration_seconds Track the duration of the repair task, in seconds
-cassandra_repair_duration_seconds{status="%s",keyspace="%s"} %d %d
+cassandra_repair_duration_seconds{status="%s"} %d %d
 '
 
 started_at=$(date +%s%3N)
@@ -23,33 +23,29 @@ started_at=$(date +%s%3N)
 function report_metrics {
     status=$1
     errno=$2
-    keyspace=$3
 
     now=$(date +%s%3N)
 
     # nb. the date must be milliseconds since the epoch
     printf "$metrics_tmpl" \
-        $status $errno $keyspace $now $status $keyspace $(((now-started_at)/1000)) $now > ${metrics_file}.$$
+        $status $errno $now $status $(((now-started_at)/1000)) $now > ${metrics_file}.$$
     mv -v ${metrics_file}.$$ ${metrics_file} || true
 }
 
-{% for keyspace in cassandra_keyspaces %}
 # Check if a repair is still running
-if ps -u cassandra -f | grep "repair {{ keyspace }}" > /dev/null
+if ps -u cassandra -f | grep "repair" > /dev/null
 then
-    report_metrics "aborted" 255 "{{ keyspace }}"
+    report_metrics "aborted" 255
     exit 255;
 fi
 
 # Run repair
 su - {{ cassandra_user }} \
-    -c '/opt/cassandra/bin/nodetool repair {{ keyspace }} -full -pr'
+    -c '/opt/cassandra/bin/nodetool repair -full -pr'
 
 if [ $? -ne 0 ]; then
   st="failed"
 else
   st="succeeded"
 fi
-report_metrics $st $? "{{ keyspace }}"
-
-{% endfor %}
+report_metrics $st $?


### PR DESCRIPTION
Fixes https://github.com/zinfra/backend-issues/issues/1701

Idea behind it is to avoid having defaults that may be risky (e.g., people not reading the docs) instead of simply repairing the whole cluster (all keyspaces). I am not sure there's a good enough reason to take that as an input.

The only thing it changes from what we do in production is that metrics are reported slightly differently but I don't see that as an issue.