### PR TITLE
Fix lookup error in hostvars if ansible_hostname != FQDN

### DIFF
--- a/templates/cqlsh.j2
+++ b/templates/cqlsh.j2
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-/opt/cassandra/bin/cqlsh {{ hostvars[ansible_hostname]["ansible_" + cassandra_network_interface]["ipv4"]["address"] }} "$@"
+/opt/cassandra/bin/cqlsh {{ hostvars[inventory_hostname]["ansible_" + cassandra_network_interface]["ipv4"]["address"] }} "$@"


### PR DESCRIPTION
if hostname on target machine is not set to FQDN, using ansible_hostname as an index to hostvars will lead to an undefined key error. -> Fixed by using inventory_hostname instead.