### PR TITLE
Allow to override the location of Cassandra's data

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ cassandra_rpc_port: 9160
 cassandra_install_parent_dir: "/opt"
 cassandra_link_dir: "/opt/cassandra"
 cassandra_install_dir: "{{ cassandra_install_parent_dir }}/apache-cassandra-{{ cassandra_version }}"
+cassandra_data_dir: "/mnt/cassandra"
 cassandra_gc_log_dir: "{{ cassandra_install_dir }}/logs"
 cassandra_group: cassandra
 cassandra_user: cassandra

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -124,9 +124,9 @@
     group: '{{ cassandra_group }}'
     mode: 0755
 
-- name: create data directories under /mnt
+- name: 'create data directories under {{ cassandra_data_dir }}'
   file:
-    path: /mnt/cassandra/{{ item }}/
+    path: '{{ cassandra_data_dir }}/{{ item }}/'
     mode: 0775
     owner: '{{ cassandra_user }}'
     group: '{{ cassandra_group }}'

--- a/templates/cassandra.yaml.j2
+++ b/templates/cassandra.yaml.j2
@@ -27,10 +27,10 @@ credentials_validity_in_ms: 2000
 partitioner: org.apache.cassandra.dht.Murmur3Partitioner
 
 # directories
-data_file_directories: [/mnt/cassandra/data]
-commitlog_directory:    /mnt/cassandra/commitlog
-saved_caches_directory: /mnt/cassandra/saved_caches
-hints_directory:        /mnt/cassandra/hints
+data_file_directories: ['{{ cassandra_data_dir }}/data']
+commitlog_directory:    '{{ cassandra_data_dir }}/commitlog'
+saved_caches_directory: '{{ cassandra_data_dir }}/saved_caches'
+hints_directory:        '{{ cassandra_data_dir }}/hints'
 
 disk_failure_policy: stop
 commit_failure_policy: stop

--- a/templates/cassandra_backup.j2
+++ b/templates/cassandra_backup.j2
@@ -11,7 +11,7 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 bucket={{ cassandra_backup_s3_bucket }}
 
-base=/mnt/cassandra/data
+base={{ cassandra_data_dir }}/data
 snaps=snapshots
 
 day_bucket=$(date +"%Y-%m-%d")

--- a/templates/cassandra_incremental_backup.j2
+++ b/templates/cassandra_incremental_backup.j2
@@ -11,7 +11,7 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 bucket={{ cassandra_backup_s3_bucket }}
 
-base=/mnt/cassandra/data
+base={{ cassandra_data_dir }}/data
 
 day_bucket=$(date +"%Y-%m-%d")
 host=$(hostname)


### PR DESCRIPTION
# What's new in this PR?

### Issues

The outer system had to be adjusted to meet the role's behaviour (location of data), which might be different from established conventions of applied environment.

### Causes (Optional)

The path where Cassandra stores it's data is hard-coded.

### Solutions

Introduce a variable allowing to override the location from the outside.

### Dependencies (Optional)

Please note that this change is fully backward-compatible, because the value defaults to the previous hard-coded one.

### Testing

This change set was successfully tested on actual machines.

### Notes (Optional)

It was recognized that when `cassandra.yml` changes, the `cassandra` service is not restarted. But this issues is considered to be out of scope for this PR.

### Attachments (Optional)

N/A
