### PR TITLE
add support for ubuntu 22.04(jammy)

### DIFF
--- a/defaults/Ubuntu-jammy.yml
+++ b/defaults/Ubuntu-jammy.yml
@@ -1,0 +1,4 @@
+---
+cassandra_dep_os_pkgs:
+  - procps
+  - libjemalloc2


### PR DESCRIPTION
Ubuntu 22.04(jammy) uses libjemalloc2 instead of libjemalloc1 library.

Created a new dependency config file for Ubuntu 22.04