### PR TITLE
Fix checksum attribute in get_url tasks to support Ansible 2.14

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -72,7 +72,7 @@
         mode: 0644
         owner: '{{ cassandra_user }}'
         group: '{{ cassandra_group }}'
-        sha256sum: '{{ cassandra_sha256 }}'
+        checksum: 'sha256:{{ cassandra_sha256 }}'
 
     - name: unpack tarball
       unarchive:
@@ -162,7 +162,7 @@
     mode: 0644
     owner: '{{ cassandra_user }}'
     group: '{{ cassandra_group }}'
-    sha256sum: '{{ prometheus_jmx_sha256 }}'
+    checksum: 'sha256:{{ prometheus_jmx_sha256 }}'
   when: cassandra_install_prometheus_jmx_exporter
 
 - name: prometheus jmx config


### PR DESCRIPTION

# What's new in this PR?

works with Ansible (core) 2.14

### Issues

throws error saying that `sha256sum` is not a supported attribute of module `get_url`

### Solutions

change `sha256sum` to `checksum` and define the algorithm name as prefix in the corresponding value, as described in the [documentation](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#parameter-checksum)

Needs releases with:

- [X] https://github.com/wireapp/wire-server-deploy/

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
