### PR TITLE
disabling incremental backups by default and introducing variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You may wish to override the following defaults to enable backups:
 ```yaml
 # backups
 cassandra_backup_enabled: false # recommended to enable this
+cassandra_incremental_backup_enabled: false # enable for built-in incremental backup routine
 cassandra_backup_s3_bucket: # set a name here and ensure hosts have access rights to an S3 bucket
 cassandra_env: dev # used in naming backups in case you have more than one environment (e.g. production, staging, ...)
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,8 @@ cassandra_disable_swap: true
 aws_cli_version: "1.16.137"
 # recommended to enable this; requires setting 'cassandra_backup_s3_bucket'
 cassandra_backup_enabled: false
+# requires setting 'cassandra_backup_s3_bucket'
+cassandra_incremental_backup_enabled: false
 # uncomment, set a name here and ensure access rights to an S3 bucket
 # cassandra_backup_s3_bucket:
 # used in naming backups in case you have more than one environment (e.g. production, staging, ...)

--- a/tasks/repairs_backups.yml
+++ b/tasks/repairs_backups.yml
@@ -9,7 +9,7 @@
     name: "awscli"
     state: present
     version: "{{ aws_cli_version }}"
-  when: cassandra_backup_enabled
+  when: cassandra_backup_enabled or cassandra_incremental_backup_enabled
 
 - name: render repair script
   template:
@@ -50,7 +50,7 @@
     mode: 0755
     owner: cassandra
     group: cassandra
-  when: cassandra_backup_enabled
+  when: cassandra_incremental_backup_enabled
   tags:
     - backup
 
@@ -73,7 +73,7 @@
     minute: '0,15,30,45'
     job: "flock -n /tmp/incr_bckup_excl_lock /usr/local/bin/cassandra_incremental_backup_{{ cassandra_cluster_name }} 2>&1 | systemd-cat -t cassandra-backup"
     state: present
-  when: cassandra_backup_enabled
+  when: cassandra_incremental_backup_enabled
   tags:
     - backup
 

--- a/templates/cassandra.yaml.j2
+++ b/templates/cassandra.yaml.j2
@@ -118,7 +118,9 @@ rpc_min_threads: 0
 rpc_max_threads: 32
 thrift_framed_transport_size_in_mb: 15
 
+{% if cassandra_incremental_backup_enabled %}
 incremental_backups: true
+{% endif %}
 
 snapshot_before_compaction: false
 auto_snapshot: true


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-9154

Incremental backups were enabled by default, which could (and did) fill up on-prem disks.
Introducing new variable, turning the functionality off by default, and only deploy incremental cronjob & incremental backup script if enabled.